### PR TITLE
Setup Adapter Completion Callback

### DIFF
--- a/Sources/UID2GMAPlugin/UID2GMAMediationAdapter.swift
+++ b/Sources/UID2GMAPlugin/UID2GMAMediationAdapter.swift
@@ -20,6 +20,10 @@ class UID2GMAMediationAdapter: NSObject {
 extension UID2GMAMediationAdapter: GADRTBAdapter {
 
     static func setUpWith(_ configuration: GADMediationServerConfiguration, completionHandler: @escaping GADMediationAdapterSetUpCompletionBlock) {
+
+        // Ensure UID2Manager has started
+        _ = UID2Manager.shared
+
         completionHandler(nil)
     }
         

--- a/Sources/UID2GMAPlugin/UID2GMAMediationAdapter.swift
+++ b/Sources/UID2GMAPlugin/UID2GMAMediationAdapter.swift
@@ -19,6 +19,10 @@ class UID2GMAMediationAdapter: NSObject {
 
 extension UID2GMAMediationAdapter: GADRTBAdapter {
 
+    static func setUpWith(_ configuration: GADMediationServerConfiguration, completionHandler: @escaping GADMediationAdapterSetUpCompletionBlock) {
+        completionHandler(nil)
+    }
+        
     func collectSignals(for params: GADRTBRequestParameters, completionHandler: @escaping GADRTBSignalCompletionHandler) {
         Task {
             guard let advertisingToken = await UID2Manager.shared.getAdvertisingToken() else {


### PR DESCRIPTION
Implements `setUpWith()` function for `GADRTBAdapter` to notify GMA SDK when Adapter has completed it's initialization process.

https://developers.google.com/admob/ios/api/reference/Protocols/GADMediationAdapter.html#+setupwithconfiguration:completionhandler:

Related:

* https://github.com/IABTechLab/uid2-android-sdk/blob/35103b9afaed0bfc5c094d0674b2f7b870d2bee2/securesignals-gma/src/main/java/com/uid2/securesignals/gma/UID2MediationAdapter.kt#L37-L48
* https://github.com/IABTechLab/uid2-ios-plugin-google-ima/pull/3
