### PR TITLE
Add CocoaPods podspec

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -10,19 +10,28 @@ on:
 jobs:
   swift-code-checks:
     name: Code Tests
-    runs-on: macos-12
+    runs-on: macos-14
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: brew install swiftlint
 
       - name: Lint code
         run: swiftlint lint --config .swiftlint.yml --reporter github-actions-logging
 
+      - name: Select Xcode 15.3
+        run: sudo xcode-select -s /Applications/Xcode_15.3.app
+
       - name: Build
-        run: xcodebuild -scheme UID2GMAPlugin -sdk iphonesimulator16.2 -destination "OS=16.2,name=iPhone 14"
+        run: xcodebuild -scheme UID2GMAPlugin -destination "generic/platform=iOS"
 
       - name: Run unit tests
-        run: xcodebuild test -scheme UID2GMAPluginTests -sdk iphonesimulator16.2 -destination "OS=16.2,name=iPhone 14"
+        run: xcodebuild test -scheme UID2GMAPluginTests -sdk iphonesimulator17.4 -destination "OS=17.4,name=iPhone 15"
+
+      - name: Lint pod spec
+        run: pod lib lint --verbose
 
   vulnerability-scan:
     name: Vulnerability Scan

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -15,12 +15,16 @@ Version Numbering follows [Semantic Versioning](https://semver.org) standards.  
       * https://github.com/IABTechLab/uid2-ios-plugin-google-gma/blob/cfc508a79af81d5b8d0aefdb60881567ea08fd24/Package.swift#L18
     * Update / Confirm `adapterVersion()` in `UID2GMAMediationAdapter.swift` is set to expected version
       * https://github.com/IABTechLab/uid2-ios-plugin-google-gma/blob/cfc508a79af81d5b8d0aefdb60881567ea08fd24/Sources/UID2GMAPlugin/UID2GMAMediationAdapter.swift#L40-L46
+    * Update / Confirm `version` and `source.tag` in `UID2GMAPlugin.podspec.json` are set to expected version
+      * https://github.com/IABTechLab/uid2-ios-plugin-google-gma/blob/main/UID2GMAPlugin.podspec.jsonL6-L12
     * Add and / or Edit any ADRs that support this release
 2. Merge Release PR into `main`
 3. Use GitHub Releases to Publish the release
     * https://github.com/IABTechLab/uid2-ios-plugin-google-gma/releases/new
     * Create tag on `main` for the commit created by merge of the Release PR
     * Document any Release Notes
-4. Create a Next Release PR
+4. Publish CocoaPod to trunk
+    * `pod trunk push UID2GMAPlugin.podspec.json`
+5. Create a Next Release PR
     * Set `adapterVersion()` in `UID2GMAMediationAdapter.swift` to the expected next (likely minor) release version of the SDK.
-5. Merge Next Release PR **BEFORE ANY CODE FOR NEXT RELEASE IS MERGED**
+6. Merge Next Release PR **BEFORE ANY CODE FOR NEXT RELEASE IS MERGED**

--- a/UID2GMAPlugin.podspec.json
+++ b/UID2GMAPlugin.podspec.json
@@ -1,0 +1,37 @@
+{
+  "name": "UID2GMAPlugin",
+  "summary": "A plugin for integrating UID2 and Google GMA into iOS applications.",
+  "homepage": "https://unifiedid.com/",
+  "license": "Apache License, Version 2.0",
+  "version": "0.3.0",
+  "authors": {
+    "David Snabel-Caunt": "dave.snabel-caunt@thetradedesk.com"
+  },
+  "source": {
+    "git": "https://github.com/IABTechLab/uid2-ios-plugin-google-gma.git",
+    "tag": "v0.3.0"
+  },
+  "platforms": {
+    "ios": "13.0"
+  },
+  "swift_versions": [
+    "5"
+  ],
+  "frameworks": "Foundation",
+  "static_framework": true,
+  "resource_bundles": {
+    "UID2": ["Sources/UID2GMAPlugin/PrivacyInfo.xcprivacy"]
+  },
+  "source_files": [
+    "Sources/UID2GMAPlugin/**/*"
+  ],
+  "dependencies": {
+    "Google-Mobile-Ads-SDK": [
+      ">= 10.7",
+      "< 12.0"
+    ],
+    "UID2": [
+      "~> 1.2"
+    ]
+  }
+}


### PR DESCRIPTION
- Add podspec
- Upgrade CI
- Add podspec lint step to CI

This pod depends on Google-Mobile-Ads-SDK >= 10.7 && < 12.0 as both major versions 10 and 11 are compatible, and flexibility will help consumers.