### PR TITLE
Expand ranges for dependency requirements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
             targets: ["UID2GMAPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/IABTechLab/uid2-ios-sdk.git", from: "0.2.0"),
-        .package(url: "https://github.com/googleads/swift-package-manager-google-mobile-ads.git", from: "10.7.0")
+        .package(url: "https://github.com/IABTechLab/uid2-ios-sdk.git", "0.2.0" ..< "2.0.0"),
+        .package(url: "https://github.com/googleads/swift-package-manager-google-mobile-ads.git", "10.7.0" ..< "12.0.0")
     ],
     targets: [
         .target(

--- a/Sources/UID2GMAPlugin/UID2GMAMediationAdapter.swift
+++ b/Sources/UID2GMAPlugin/UID2GMAMediationAdapter.swift
@@ -42,7 +42,7 @@ extension UID2GMAMediationAdapter: GADRTBAdapter {
         var version = GADVersionNumber()
         version.majorVersion = 0
         version.minorVersion = 3
-        version.patchVersion = 0
+        version.patchVersion = 1
         return version
     }
     

--- a/UID2GMAPlugin.podspec.json
+++ b/UID2GMAPlugin.podspec.json
@@ -3,13 +3,13 @@
   "summary": "A plugin for integrating UID2 and Google GMA into iOS applications.",
   "homepage": "https://unifiedid.com/",
   "license": "Apache License, Version 2.0",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "authors": {
     "David Snabel-Caunt": "dave.snabel-caunt@thetradedesk.com"
   },
   "source": {
     "git": "https://github.com/IABTechLab/uid2-ios-plugin-google-gma.git",
-    "tag": "v0.3.0"
+    "tag": "v0.3.1"
   },
   "platforms": {
     "ios": "13.0"
@@ -31,7 +31,8 @@
       "< 12.0"
     ],
     "UID2": [
-      "~> 1.2"
+      ">= 0.2",
+      "< 2.0"
     ]
   }
 }


### PR DESCRIPTION
Additionally allow v11 of the Google Mobile Ads SDK. Version bump to 0.3.1.