### PR TITLE
Prefix error symbol for Objective-C

### DIFF
--- a/Sources/UID2GMAPlugin/AdvertisingTokenNotFoundError.swift
+++ b/Sources/UID2GMAPlugin/AdvertisingTokenNotFoundError.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-/// Advertising Token Not Found for IMA Adapter
-@objc(AdvertisingTokenNotFoundError)
+/// Advertising Token Not Found for GMA Adapter
+@objc(UID2GMAAdvertisingTokenNotFoundError)
 public class AdvertisingTokenNotFoundError: NSError {
     
     convenience init() {

--- a/Sources/UID2GMAPlugin/UID2GMAMediationAdapter.swift
+++ b/Sources/UID2GMAPlugin/UID2GMAMediationAdapter.swift
@@ -42,7 +42,7 @@ extension UID2GMAMediationAdapter: GADRTBAdapter {
         var version = GADVersionNumber()
         version.majorVersion = 0
         version.minorVersion = 3
-        version.patchVersion = 1
+        version.patchVersion = 2
         return version
     }
     

--- a/UID2GMAPlugin.podspec.json
+++ b/UID2GMAPlugin.podspec.json
@@ -3,13 +3,13 @@
   "summary": "A plugin for integrating UID2 and Google GMA into iOS applications.",
   "homepage": "https://unifiedid.com/",
   "license": "Apache License, Version 2.0",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "authors": {
     "David Snabel-Caunt": "dave.snabel-caunt@thetradedesk.com"
   },
   "source": {
     "git": "https://github.com/IABTechLab/uid2-ios-plugin-google-gma.git",
-    "tag": "v0.3.1"
+    "tag": "v0.3.2"
   },
   "platforms": {
     "ios": "13.0"


### PR DESCRIPTION
Objective-C symbols should be prefixed to avoid conflicts.`AdvertisingTokenNotFoundError`'s Objective-C name currently conflicts with the UDI2 IMA plugin.