### PR TITLE
Fix resource bundle name conflict

### DIFF
--- a/Sources/UID2GMAPlugin/UID2GMAMediationAdapter.swift
+++ b/Sources/UID2GMAPlugin/UID2GMAMediationAdapter.swift
@@ -42,7 +42,7 @@ extension UID2GMAMediationAdapter: GADRTBAdapter {
         var version = GADVersionNumber()
         version.majorVersion = 0
         version.minorVersion = 3
-        version.patchVersion = 2
+        version.patchVersion = 3
         return version
     }
     

--- a/UID2GMAPlugin.podspec.json
+++ b/UID2GMAPlugin.podspec.json
@@ -3,13 +3,13 @@
   "summary": "A plugin for integrating UID2 and Google GMA into iOS applications.",
   "homepage": "https://unifiedid.com/",
   "license": "Apache License, Version 2.0",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "authors": {
     "David Snabel-Caunt": "dave.snabel-caunt@thetradedesk.com"
   },
   "source": {
     "git": "https://github.com/IABTechLab/uid2-ios-plugin-google-gma.git",
-    "tag": "v0.3.2"
+    "tag": "v0.3.3"
   },
   "platforms": {
     "ios": "13.0"
@@ -20,7 +20,7 @@
   "frameworks": "Foundation",
   "static_framework": true,
   "resource_bundles": {
-    "UID2": ["Sources/UID2GMAPlugin/PrivacyInfo.xcprivacy"]
+    "UID2GMAPlugin": ["Sources/UID2GMAPlugin/PrivacyInfo.xcprivacy"]
   },
   "source_files": [
     "Sources/UID2GMAPlugin/**/*"


### PR DESCRIPTION
The podspec mistakenly uses the resource bundle name `UID2` which causes Xcode archiving to fail, as it will conflict with the UID2 SDK's resource bundle. Rename to match the spec name.

Bump version to 0.3.3 ready to release.