### PR TITLE
Simplify adapter tests

### DIFF
--- a/Tests/UID2GMAPluginTests/TestExtensions/GADRTBAdapter+TestExtensions.swift
+++ b/Tests/UID2GMAPluginTests/TestExtensions/GADRTBAdapter+TestExtensions.swift
@@ -1,0 +1,20 @@
+//
+//  GADRTBAdapter.swift
+//
+
+import GoogleMobileAds
+
+/// Adds an async wrapper interface to simplify testing
+extension GADRTBAdapter {
+    func collectSignals(for params: GADRTBRequestParameters) async throws -> String? {
+        try await withCheckedThrowingContinuation { continuation in
+            collectSignals(for: params, completionHandler: { signal, error in
+                guard error == nil else {
+                    continuation.resume(throwing: error!)
+                    return
+                }
+                continuation.resume(returning: signal)
+            })
+        }
+    }
+}

--- a/Tests/UID2GMAPluginTests/UID2GMAMediationAdapterTests.swift
+++ b/Tests/UID2GMAPluginTests/UID2GMAMediationAdapterTests.swift
@@ -11,115 +11,72 @@ import UID2
 @testable import UID2GMAPlugin
 
 final class UID2GMAMediationAdapterTests: XCTestCase {
-
-    private let decoder: JSONDecoder = {
-        let decoder = JSONDecoder()
-        decoder.keyDecodingStrategy = .convertFromSnakeCase
-        return decoder
-    }()
-    
-    
     /// 🟩 - GMA Adapter Request Signal Success
     func testRequestSignalsSuccess() async throws {
-        
-        // Sample UID2Identity data
-        let uid2IdentityData = try DataLoader.load(fileName: "uid2identity", fileExtension: "json")
-        let uid2IdentityFromFile = try decoder.decode(UID2Identity.self, from: uid2IdentityData)
-        
-        // Emulate A UID2Identity With Valid Times
-        let identityExpires = Date(timeIntervalSinceNow: 60 * 60).millisecondsSince1970
-        let refreshFrom = Date(timeIntervalSinceNow: 60 * 40).millisecondsSince1970
-        let refreshExpires = Date(timeIntervalSinceNow: 60 * 50).millisecondsSince1970
-        
-        let uid2Identity = UID2Identity(advertisingToken: uid2IdentityFromFile.advertisingToken,
-                                        refreshToken: uid2IdentityFromFile.refreshToken,
-                                        identityExpires: identityExpires,
-                                        refreshFrom: refreshFrom,
-                                        refreshExpires: refreshExpires,
-                                        refreshResponseKey: uid2IdentityFromFile.refreshResponseKey)
-        
         // Seed the sample UID2Identity data in the UID2Manager
         await UID2Manager.shared.setAutomaticRefreshEnabled(false)
-        await UID2Manager.shared.setIdentity(uid2Identity)
+        await UID2Manager.shared.setIdentity(
+            UID2Identity(
+                advertisingToken: "uid2-test-token",
+                refreshToken: "refresh-token",
+                identityExpires: Date(timeIntervalSinceNow: 60 * 60).millisecondsSince1970,
+                refreshFrom: Date(timeIntervalSinceNow: 60 * 40).millisecondsSince1970,
+                refreshExpires: Date(timeIntervalSinceNow: 60 * 50).millisecondsSince1970,
+                refreshResponseKey: ""
+            )
+        )
 
-        // Adapter to test
-        let adapter = UID2GMAMediationAdapter()
-        
-        // Wraps Completion Handler Function Call In Async / Await
-        let signal: String = try await withCheckedThrowingContinuation { continuation in
-            
-            adapter.collectSignals(for: GADRTBRequestParameters(), completionHandler:  { signal, error in
-                guard let signal = signal else {
-                    continuation.resume(throwing: "Signal was Nil")
-                    return
-                }
-                continuation.resume(returning: signal)
-                return
-            })
-            
-        }
-    
+        let signal = try await UID2GMAMediationAdapter().collectSignals(for: GADRTBRequestParameters())
+
         // Confirm that Adapter returns expected data
-        XCTAssertEqual(uid2Identity.advertisingToken, signal)
+        XCTAssertEqual("uid2-test-token", signal)
     }
-    
-    /// 🟥  - GMA Adapter Request Signal No Advertising Token Erro
-    func testRequestSignalsNoAdvertisingToken() async throws {
-        
-        // Sample UID2Identity data
-        let uid2IdentityData = try DataLoader.load(fileName: "uid2identity", fileExtension: "json")
-        let uid2IdentityFromFile = try decoder.decode(UID2Identity.self, from: uid2IdentityData)
-        
-        // Emulate A UID2Identity With Valid Times
-        let identityExpires = Date(timeIntervalSinceNow: 60 * 60).millisecondsSince1970
-        let refreshFrom = Date(timeIntervalSinceNow: 60 * 40).millisecondsSince1970
-        let refreshExpires = Date(timeIntervalSinceNow: 60 * 50).millisecondsSince1970
-        
-        let uid2Identity = UID2Identity(advertisingToken: "",
-                                        refreshToken: uid2IdentityFromFile.refreshToken,
-                                        identityExpires: identityExpires,
-                                        refreshFrom: refreshFrom,
-                                        refreshExpires: refreshExpires,
-                                        refreshResponseKey: uid2IdentityFromFile.refreshResponseKey)
-        
-        // Seed the sample UID2Identity data in the UID2Manager
-        await UID2Manager.shared.setAutomaticRefreshEnabled(false)
-        await UID2Manager.shared.setIdentity(uid2Identity)
 
-        // Adapter to test
-        let adapter = UID2GMAMediationAdapter()
-        
-        // Wraps Completion Handler Function Call In Async / Await
-        let _: String = try await withCheckedThrowingContinuation { continuation in
-            
-            adapter.collectSignals(for: GADRTBRequestParameters(), completionHandler:  { signal, error in
-                
-                guard let error = error as? AdvertisingTokenNotFoundError else {
-                    continuation.resume(throwing: "Error returned was not expected type.")
-                    return
-                }
-                
-                XCTAssertEqual(AdvertisingTokenNotFoundError(), error)
-            
-                continuation.resume(returning: "Successful Test")
-                
-                return
-            })
-            
+    /// 🟥 - GMA Adapter Request Signal Error No Identity
+    func testRequestSignalsNoIdentity() async throws {
+        // Ensure no identity is set
+        await UID2Manager.shared.resetIdentity()
+
+        let result = await Task<String?, Error> {
+            try await UID2GMAMediationAdapter().collectSignals(for: GADRTBRequestParameters())
+        }.result
+        XCTAssertThrowsError(try result.get()) { error in
+            let adapterError = error as? AdvertisingTokenNotFoundError
+            XCTAssertEqual(AdvertisingTokenNotFoundError(), adapterError)
         }
-    
     }
-    
+
+    /// 🟥  - GMA Adapter Request Signal No Advertising Token Error
+    func testRequestSignalsNoAdvertisingToken() async throws {
+        // Set an identity with an invalid advertisingToken
+        await UID2Manager.shared.setAutomaticRefreshEnabled(false)
+        await UID2Manager.shared.setIdentity(
+            UID2Identity(
+                advertisingToken: "",
+                refreshToken: "refresh-token",
+                identityExpires: Date(timeIntervalSinceNow: 60 * 60).millisecondsSince1970,
+                refreshFrom: Date(timeIntervalSinceNow: 60 * 40).millisecondsSince1970,
+                refreshExpires: Date(timeIntervalSinceNow: 60 * 50).millisecondsSince1970,
+                refreshResponseKey: ""
+            )
+        )
+
+        let result = await Task<String?, Error> {
+            try await UID2GMAMediationAdapter().collectSignals(for: GADRTBRequestParameters())
+        }.result
+        XCTAssertThrowsError(try result.get()) { error in
+            let adapterError = error as? AdvertisingTokenNotFoundError
+            XCTAssertEqual(AdvertisingTokenNotFoundError(), adapterError)
+        }
+    }
+
     /// 🟩 - GMA Adapter Ad SDK Version Check Success
     func testAdSDKVersion() async throws {
-        
         let adSDKVersion = UID2GMAMediationAdapter.adSDKVersion()
         let sdkVersion = await UID2Manager.shared.sdkVersion
         
         XCTAssertEqual(sdkVersion.major, adSDKVersion.majorVersion)
         XCTAssertEqual(sdkVersion.minor, adSDKVersion.minorVersion)
         XCTAssertEqual(sdkVersion.patch, adSDKVersion.patchVersion)
-
     }
-    
 }


### PR DESCRIPTION
- Add an async extension to `GADRTBAdapter` to make tests easier to follow
- Add a test for no identity