### PR TITLE
Check iOS 13 is available at runtime

### DIFF
--- a/Sources/UID2GMAPlugin/AdvertisingTokenNotFoundError.swift
+++ b/Sources/UID2GMAPlugin/AdvertisingTokenNotFoundError.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Advertising Token Not Found for GMA Adapter
 @objc(UID2GMAAdvertisingTokenNotFoundError)
-public class AdvertisingTokenNotFoundError: NSError {
+public class AdvertisingTokenNotFoundError: NSError, @unchecked Sendable {
     
     convenience init() {
         self.init(domain: "UID", code: 1)

--- a/Sources/UID2GMAPlugin/EUIDGMAMediationAdapter.swift
+++ b/Sources/UID2GMAPlugin/EUIDGMAMediationAdapter.swift
@@ -20,7 +20,10 @@ class EUIDGMAMediationAdapter: NSObject {
 extension EUIDGMAMediationAdapter: GADRTBAdapter {
 
     static func setUpWith(_ configuration: GADMediationServerConfiguration, completionHandler: @escaping GADMediationAdapterSetUpCompletionBlock) {
-
+        guard isOperatingSystemSupported else {
+            completionHandler(OperatingSystemUnsupportedError())
+            return
+        }
         // Ensure UID2Manager has started
         _ = EUIDManager.shared
 
@@ -28,6 +31,10 @@ extension EUIDGMAMediationAdapter: GADRTBAdapter {
     }
 
     func collectSignals(for params: GADRTBRequestParameters, completionHandler: @escaping GADRTBSignalCompletionHandler) {
+        guard isOperatingSystemSupported else {
+            completionHandler(nil, OperatingSystemUnsupportedError())
+            return
+        }
         Task {
             guard let advertisingToken = await EUIDManager.shared.getAdvertisingToken() else {
                 completionHandler(nil, AdvertisingTokenNotFoundError())
@@ -41,7 +48,7 @@ extension EUIDGMAMediationAdapter: GADRTBAdapter {
         var version = GADVersionNumber()
         version.majorVersion = 1
         version.minorVersion = 0
-        version.patchVersion = 0
+        version.patchVersion = 1
         return version
     }
 

--- a/Sources/UID2GMAPlugin/OperatingSystemSupport.swift
+++ b/Sources/UID2GMAPlugin/OperatingSystemSupport.swift
@@ -1,0 +1,24 @@
+//
+//  OperatingSystemUnsupportedError.swift
+//
+
+import Foundation
+
+/// Adapter implementations in this package are called at runtime, ignoring @available attributes.
+/// By checking the operating system version we can avoid calling UID code which is unavailable.
+let isOperatingSystemSupported = ProcessInfo.processInfo.isOperatingSystemAtLeast(
+    .init(
+        majorVersion: 13,
+        minorVersion: 0,
+        patchVersion: 0
+    )
+)
+
+/// Adapter called on an unsupported operating system version i.e. lower than UID2's deployment target.
+@objc(UID2GMAOperatingSystemUnsupported)
+public final class OperatingSystemUnsupportedError: NSError, @unchecked Sendable {
+
+    convenience init() {
+        self.init(domain: "UID", code: 2)
+    }
+}

--- a/Sources/UID2GMAPlugin/UID2GMAMediationAdapter.swift
+++ b/Sources/UID2GMAPlugin/UID2GMAMediationAdapter.swift
@@ -23,7 +23,10 @@ class UID2GMAMediationAdapter: NSObject {
 extension UID2GMAMediationAdapter: GADRTBAdapter {
 
     static func setUpWith(_ configuration: GADMediationServerConfiguration, completionHandler: @escaping GADMediationAdapterSetUpCompletionBlock) {
-
+        guard isOperatingSystemSupported else {
+            completionHandler(OperatingSystemUnsupportedError())
+            return
+        }
         // Ensure UID2Manager has started
         _ = UID2Manager.shared
 
@@ -31,6 +34,10 @@ extension UID2GMAMediationAdapter: GADRTBAdapter {
     }
         
     func collectSignals(for params: GADRTBRequestParameters, completionHandler: @escaping GADRTBSignalCompletionHandler) {
+        guard isOperatingSystemSupported else {
+            completionHandler(nil, OperatingSystemUnsupportedError())
+            return
+        }
         Task {
             guard let advertisingToken = await UID2Manager.shared.getAdvertisingToken() else {
                 completionHandler(nil, AdvertisingTokenNotFoundError())
@@ -44,7 +51,7 @@ extension UID2GMAMediationAdapter: GADRTBAdapter {
         var version = GADVersionNumber()
         version.majorVersion = 1
         version.minorVersion = 0
-        version.patchVersion = 0
+        version.patchVersion = 1
         return version
     }
     

--- a/UID2GMAPlugin.podspec.json
+++ b/UID2GMAPlugin.podspec.json
@@ -3,13 +3,13 @@
   "summary": "A plugin for integrating UID2 and Google GMA into iOS applications.",
   "homepage": "https://unifiedid.com/",
   "license": "Apache License, Version 2.0",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "authors": {
     "David Snabel-Caunt": "dave.snabel-caunt@thetradedesk.com"
   },
   "source": {
     "git": "https://github.com/IABTechLab/uid2-ios-plugin-google-gma.git",
-    "tag": "v1.0.0"
+    "tag": "v1.0.1"
   },
   "platforms": {
     "ios": "12.0"


### PR DESCRIPTION
Fixes a crash on iOS 12 when the adapters are called at runtime.

Check and cache operating system version, using this to no-op adapter calls on operating systems prior to iOS 13. `#available` checks do work for this, but produce a warning because the compiler knows the enclosing scope is already annotated with @available. Using ProcessInfo avoids these warnings.