### PR TITLE
Support Google Mobile Ads v13

### DIFF
--- a/Development/UID2GoogleGMADevelopmentApp/UID2GoogleGMADevelopmentApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Development/UID2GoogleGMADevelopmentApp/UID2GoogleGMADevelopmentApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/swift-package-manager-google-mobile-ads.git",
       "state" : {
-        "revision" : "356bebbc5b84c07a7b7cdd744b22829bf5ad4e76",
-        "version" : "12.1.0"
+        "revision" : "4458cfaeb502801c779dbb7fbd0121d198628f52",
+        "version" : "13.1.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/swift-package-manager-google-mobile-ads.git",
       "state" : {
-        "revision" : "356bebbc5b84c07a7b7cdd744b22829bf5ad4e76",
-        "version" : "12.1.0"
+        "revision" : "4458cfaeb502801c779dbb7fbd0121d198628f52",
+        "version" : "13.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "UID2GMAPlugin",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v12)
+        .iOS(.v13)
     ],
     products: [
         .library(
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/IABTechLab/uid2-ios-sdk.git", "1.7.0" ..< "3.0.0"),
-        .package(url: "https://github.com/googleads/swift-package-manager-google-mobile-ads.git", .upToNextMajor(from: "12.0.0"))
+        .package(url: "https://github.com/googleads/swift-package-manager-google-mobile-ads.git", .upToNextMajor(from: "13.0.0"))
     ],
     targets: [
         .target(

--- a/Sources/UID2GMAPlugin/EUIDGMAMediationAdapter.swift
+++ b/Sources/UID2GMAPlugin/EUIDGMAMediationAdapter.swift
@@ -46,9 +46,9 @@ extension EUIDGMAMediationAdapter: RTBAdapter {
 
     static func adapterVersion() -> VersionNumber {
         var version = VersionNumber()
-        version.majorVersion = 2
+        version.majorVersion = 3
         version.minorVersion = 0
-        version.patchVersion = 2
+        version.patchVersion = 0
         return version
     }
 

--- a/Sources/UID2GMAPlugin/UID2GMAMediationAdapter.swift
+++ b/Sources/UID2GMAPlugin/UID2GMAMediationAdapter.swift
@@ -49,9 +49,9 @@ extension UID2GMAMediationAdapter: RTBAdapter {
     
     static func adapterVersion() -> VersionNumber {
         var version = VersionNumber()
-        version.majorVersion = 2
+        version.majorVersion = 3
         version.minorVersion = 0
-        version.patchVersion = 2
+        version.patchVersion = 0
         return version
     }
     

--- a/UID2GMAPlugin.podspec.json
+++ b/UID2GMAPlugin.podspec.json
@@ -3,16 +3,16 @@
   "summary": "A plugin for integrating UID2 and Google GMA into iOS applications.",
   "homepage": "https://unifiedid.com/",
   "license": "Apache License, Version 2.0",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "authors": {
     "David Snabel-Caunt": "dave.snabel-caunt@thetradedesk.com"
   },
   "source": {
     "git": "https://github.com/IABTechLab/uid2-ios-plugin-google-gma.git",
-    "tag": "v2.0.2"
+    "tag": "v3.0.0"
   },
   "platforms": {
-    "ios": "12.0"
+    "ios": "13.0"
   },
   "swift_versions": [
     "5"
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "Google-Mobile-Ads-SDK": [
-      "~> 12.0"
+      "~> 13.0"
     ],
     "UID2": [
       ">= 1.7.0",


### PR DESCRIPTION
Support Google Mobile Ads SDK version 13.

Bump minimum supported iOS version from 12 to 13. This is the lowest supported by GMA 13, and Swift Package Manager requires that our min version is at least that of the lowest of our dependencies. 

Update podspec ready for release 3.0.0.