### PR TITLE
Support UID2 SDK v3

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -30,8 +30,9 @@ jobs:
       - name: Run unit tests
         run: xcodebuild test -scheme UID2GMAPluginTests -destination "OS=18.2,name=iPhone 16"
 
+        # Use --allow-warnings because the GMA plugin emits warnings outside of our control
       - name: Lint pod spec
-        run: pod lib lint --verbose
+        run: pod lib lint --verbose --allow-warnings
 
   vulnerability-scan:
     name: Vulnerability Scan

--- a/Development/UID2GoogleGMADevelopmentApp/UID2GoogleGMADevelopmentApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Development/UID2GoogleGMADevelopmentApp/UID2GoogleGMADevelopmentApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,30 @@
 {
   "pins" : [
     {
+      "identity" : "applovin-max-swift-package",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AppLovin/AppLovin-MAX-Swift-Package.git",
+      "state" : {
+        "revision" : "d829feb5b7de8755e9a1834c2e1e0b95c9126424",
+        "version" : "13.6.2"
+      }
+    },
+    {
+      "identity" : "prebid-mobile-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/prebid/prebid-mobile-ios.git",
+      "state" : {
+        "revision" : "4f96890f9f8b38db6abd92044a928a709d5458d2",
+        "version" : "3.3.1"
+      }
+    },
+    {
       "identity" : "swift-asn1",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "c7e239b5c1492ffc3ebd7fbcc7a92548ce4e78f0",
-        "version" : "1.1.0"
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
       }
     },
     {
@@ -14,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/swift-package-manager-google-mobile-ads.git",
       "state" : {
-        "revision" : "4458cfaeb502801c779dbb7fbd0121d198628f52",
-        "version" : "13.1.0"
+        "revision" : "a81f522aa4f59c0d90ee523d703bd426d5b27a03",
+        "version" : "13.4.0"
       }
     },
     {
@@ -32,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/IABTechLab/uid2-ios-sdk.git",
       "state" : {
-        "revision" : "02dc358fa6977357bffc12bad81c7d5650170e27",
-        "version" : "1.7.0"
+        "revision" : "6c5a119212623fa2bc51f55cf5e3e973d500a7d6",
+        "version" : "3.0.2"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,30 @@
 {
   "pins" : [
     {
+      "identity" : "applovin-max-swift-package",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AppLovin/AppLovin-MAX-Swift-Package.git",
+      "state" : {
+        "revision" : "d829feb5b7de8755e9a1834c2e1e0b95c9126424",
+        "version" : "13.6.2"
+      }
+    },
+    {
+      "identity" : "prebid-mobile-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/prebid/prebid-mobile-ios.git",
+      "state" : {
+        "revision" : "4f96890f9f8b38db6abd92044a928a709d5458d2",
+        "version" : "3.3.1"
+      }
+    },
+    {
       "identity" : "swift-asn1",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "c7e239b5c1492ffc3ebd7fbcc7a92548ce4e78f0",
-        "version" : "1.1.0"
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
       }
     },
     {
@@ -14,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/swift-package-manager-google-mobile-ads.git",
       "state" : {
-        "revision" : "4458cfaeb502801c779dbb7fbd0121d198628f52",
-        "version" : "13.1.0"
+        "revision" : "a81f522aa4f59c0d90ee523d703bd426d5b27a03",
+        "version" : "13.4.0"
       }
     },
     {
@@ -32,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/IABTechLab/uid2-ios-sdk.git",
       "state" : {
-        "revision" : "02dc358fa6977357bffc12bad81c7d5650170e27",
-        "version" : "1.7.0"
+        "revision" : "6c5a119212623fa2bc51f55cf5e3e973d500a7d6",
+        "version" : "3.0.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["UID2GMAPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/IABTechLab/uid2-ios-sdk.git", "1.7.0" ..< "3.0.0"),
+        .package(url: "https://github.com/IABTechLab/uid2-ios-sdk.git", "1.7.0" ..< "4.0.0"),
         .package(url: "https://github.com/googleads/swift-package-manager-google-mobile-ads.git", .upToNextMajor(from: "13.0.0"))
     ],
     targets: [

--- a/Sources/UID2GMAPlugin/EUIDGMAMediationAdapter.swift
+++ b/Sources/UID2GMAPlugin/EUIDGMAMediationAdapter.swift
@@ -48,7 +48,7 @@ extension EUIDGMAMediationAdapter: RTBAdapter {
         var version = VersionNumber()
         version.majorVersion = 3
         version.minorVersion = 0
-        version.patchVersion = 0
+        version.patchVersion = 1
         return version
     }
 

--- a/Sources/UID2GMAPlugin/UID2GMAMediationAdapter.swift
+++ b/Sources/UID2GMAPlugin/UID2GMAMediationAdapter.swift
@@ -51,7 +51,7 @@ extension UID2GMAMediationAdapter: RTBAdapter {
         var version = VersionNumber()
         version.majorVersion = 3
         version.minorVersion = 0
-        version.patchVersion = 0
+        version.patchVersion = 1
         return version
     }
     

--- a/UID2GMAPlugin.podspec.json
+++ b/UID2GMAPlugin.podspec.json
@@ -3,13 +3,13 @@
   "summary": "A plugin for integrating UID2 and Google GMA into iOS applications.",
   "homepage": "https://unifiedid.com/",
   "license": "Apache License, Version 2.0",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "authors": {
     "David Snabel-Caunt": "dave.snabel-caunt@thetradedesk.com"
   },
   "source": {
     "git": "https://github.com/IABTechLab/uid2-ios-plugin-google-gma.git",
-    "tag": "v3.0.0"
+    "tag": "v3.0.1"
   },
   "platforms": {
     "ios": "13.0"
@@ -31,7 +31,7 @@
     ],
     "UID2": [
       ">= 1.7.0",
-      "< 3.0"
+      "< 4.0"
     ]
   }
 }


### PR DESCRIPTION
- Expand SPM and CocoaPods versioning to include v3 of the UID2 SDK
- Bump version numbers and CocoaPod spec ready for release

This PR also adds the `--allow-warnings` flag to the CocoaPods lint step. This is unavoidable while the GMA dependency is emitting warnings.