### PR TITLE
chore: bump podspec to v3.1.0

### DIFF
--- a/UID2GMAPlugin.podspec.json
+++ b/UID2GMAPlugin.podspec.json
@@ -3,13 +3,13 @@
   "summary": "A plugin for integrating UID2 and Google GMA into iOS applications.",
   "homepage": "https://unifiedid.com/",
   "license": "Apache License, Version 2.0",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "authors": {
     "David Snabel-Caunt": "dave.snabel-caunt@thetradedesk.com"
   },
   "source": {
     "git": "https://github.com/IABTechLab/uid2-ios-plugin-google-gma.git",
-    "tag": "v3.0.1"
+    "tag": "v3.1.0"
   },
   "platforms": {
     "ios": "13.0"


### PR DESCRIPTION
## Summary
- Updates `UID2GMAPlugin.podspec.json` version from `3.0.1` to `3.1.0`
- Updates `source.tag` from `v3.0.1` to `v3.1.0` to match the GitHub Release tag

Required so `pod trunk push UID2GMAPlugin.podspec.json` can publish v3.1.0 to CocoaPods trunk.